### PR TITLE
Basic OpenVPN support, very untested.

### DIFF
--- a/config-navipoint.hs
+++ b/config-navipoint.hs
@@ -1,0 +1,19 @@
+-- | Navipoint system configuration settings.
+
+import Propellor
+import qualified Propellor.Property.Apt as Apt
+import qualified Propellor.Property.OpenVPN as OVPN
+
+main :: IO ()
+main = defaultMain hosts
+
+hosts :: [Host]
+hosts = [navipoint_vpn]
+
+navipoint_vpn :: Host
+navipoint_vpn = host "52.70.117.175"
+	& os (System (Buntish "trusty") "amd64")
+	& Apt.unattendedUpgrades
+	& Apt.update
+	& Apt.upgrade
+	& OVPN.openvpn "navipoint" "10.241.0.0" "255.255.254.0" [] False 2048

--- a/config.hs
+++ b/config.hs
@@ -1,1 +1,1 @@
-config-simple.hs
+config-navipoint.hs

--- a/propellor.cabal
+++ b/propellor.cabal
@@ -59,7 +59,6 @@ Library
    IfElse, process, bytestring, hslogger, unix-compat, ansi-terminal,
    containers (>= 0.5), network, async, time, mtl, transformers,
    exceptions (>= 0.6), stm, text, unix
-
   Exposed-Modules:
     Propellor
     Propellor.Base

--- a/src/Propellor/Bootstrap.hs
+++ b/src/Propellor/Bootstrap.hs
@@ -59,10 +59,11 @@ depsCommand msys = "( " ++ intercalate " ; " (concat [osinstall, cabalinstall]) 
 	osinstall = case msys of
 		Just (System (FreeBSD _) _) -> map pkginstall fbsddeps
 		Just (System (Debian _) _) -> useapt
-		Just (System (Buntish _) _) -> useapt
+		Just (System (Buntish _) _) -> getppa:useapt
 		-- assume a debian derived system when not specified
 		Nothing -> useapt
 
+	getppa = "add-apt-repository ppa:jtgeibel/ghc-7.10.3"
 	useapt = "apt-get update" : map aptinstall debdeps
 
 	cabalinstall =
@@ -123,7 +124,7 @@ installGitCommand msys = case msys of
 	Nothing -> use apt
   where
 	use cmds = "if ! git --version >/dev/null; then " ++ intercalate " && " cmds ++ "; fi"
-	apt = 
+	apt =
 		[ "apt-get update"
 		, "DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --no-upgrade -y install git"
 		]

--- a/src/Propellor/Property/OpenVPN.hs
+++ b/src/Propellor/Property/OpenVPN.hs
@@ -1,0 +1,165 @@
+{-# Language OverloadedStrings #-}
+
+-- | Maintainer: Evan Cofsky <evan@theunixman.com>
+
+module Propellor.Property.OpenVPN where
+
+import Data.List (intercalate)
+
+import Propellor.Base
+import Utility.FileMode
+import System.Posix.Files
+
+import qualified Propellor.Property.File as File
+import qualified Propellor.Property.Apt as Apt
+import qualified Propellor.Property.Service as Service
+
+type VPNInstance = String
+type ConfigFile = FilePath
+
+openvpn :: VPNInstance -> String -> String -> [String] -> Bool -> Int -> CombinedType (Property NoInfo) (Property HasInfo)
+openvpn inst addrBase addrMask dnsServers redirectGateway dhbits =
+	latestInstalled
+	`before` combineProperties ("creating config dirs for " ++ inst) [configDirExists inst, certsDirExists inst]
+	`before` genDhParams inst dhbits
+	`before` installPems inst
+	`before` installConfig inst addrBase addrMask dnsServers redirectGateway dhbits
+	`before` Service.restarted "openvpn"
+
+latestInstalled :: CombinedType (Property HasInfo) (Property NoInfo)
+latestInstalled = installOVPNGpgKey `before` installOVPNRepo `before` Apt.update `before` Apt.installed ["openvpn"]
+
+installOVPNGpgKey :: Property HasInfo
+installOVPNGpgKey =
+	withPrivData GpgKey (Context "openvpn.repository") $
+		\getkey -> property "Trust OpenVPN repository GPG key" $
+			getkey $ \key -> aptKey $ privDataLines key
+  where
+	aptKey key =
+		let
+			writer h = hPutStr h (unlines key)
+		in
+			liftIO $ writeReadProcessEnv "apt-key" ["add", "-"] Nothing (Just writer) Nothing >> return MadeChange
+
+installOVPNRepo :: Property NoInfo
+installOVPNRepo =
+	Apt.setSourcesListD ["deb http://swupdate.openvpn.net/apt trusty main"] "openvpn"
+
+configDirExists :: VPNInstance -> Property NoInfo
+configDirExists = dirExists . instConfigDir
+
+certsDirExists :: VPNInstance -> Property NoInfo
+certsDirExists = dirExists . instPkiDir
+
+dirExists :: FilePath -> Property NoInfo
+dirExists d =
+	File.dirExists d
+	`before` File.mode d (combineModes [ownerReadMode, ownerWriteMode, ownerExecuteMode])
+
+-- | Root of the OpenVPN configuration
+--
+-- This is where the instance openvpn config file will go.
+openVPNConfDir :: FilePath
+openVPNConfDir = "/etc/openvpn"
+
+confFilePath :: VPNInstance -> FilePath
+confFilePath inst = openVPNConfDir </> inst <.> "conf"
+
+-- | Absolute path to the configuration for this instance
+instConfigDir :: VPNInstance -> FilePath
+instConfigDir inst = openVPNConfDir </> inst
+
+-- | Absolute path to the instance PKI directory
+instPkiDir :: VPNInstance -> FilePath
+instPkiDir inst = instConfigDir inst </> "pki"
+
+pkiFileName :: VPNInstance -> SSLType -> FilePath
+pkiFileName inst typ = instPkiDir inst </> fileName inst typ
+
+-- | Generates the DH Parameters
+genDhParams :: VPNInstance -> DHBits -> Property NoInfo
+genDhParams inst bits =
+	let
+		dhpem = pkiFileName inst (DHParams bits)
+		gendh = cmdProperty "openssl" ["dhparam", "-out", dhpem, show bits]
+	in
+		check (not <$> doesFileExist dhpem) gendh
+
+installPems :: VPNInstance -> Property HasInfo
+installPems inst =
+  combineProperties ("Install PKI PEMS for " ++ inst) $ map (installPem inst) [CRL, Chain, Certificate, RSAKey]
+
+-- | Install a pem file from private data
+--
+-- The context should be "openvpn.<instance name>"
+installPem :: VPNInstance -> SSLType -> Property HasInfo
+installPem inst typ =
+	let
+		privCtx = Context $ intercalate "." ["openvpn", inst]
+	in
+		File.hasPrivContent (pkiFileName inst typ) privCtx
+
+installConfig :: VPNInstance -> String -> String -> [String] -> Bool -> Int -> Property NoInfo
+installConfig inst addrBase addrMask dnsServers redirectGateway dhbits =
+	let
+		config = genConfig inst addrBase addrMask dnsServers redirectGateway dhbits
+	in
+		File.hasContent (confFilePath inst) config
+
+genConfig :: VPNInstance -> String -> String -> [String] -> Bool ->Int -> [String]
+genConfig inst addrBase addrMask dnsServers redirectGateway dhbits =
+	let
+		confItem :: String -> String -> [String]
+		confItem key val = [intercalate " " [key, val]]
+
+		qs :: String -> String
+		qs s = intercalate "" ["\"", s, "\""]
+
+		push vals = confItem "push" $ qs (intercalate " " vals)
+
+		serverOpt = confItem "server" (intercalate " " [addrBase, addrMask])
+		pemOpts = concatMap (\(k, t) -> confItem k (pkiFileName inst t)) $
+			zip ["ca", "key", "cert", "crl-verify"] [Chain, RSAKey, Certificate, CRL]
+		dnsOpts = concatMap (\s -> push ["dhcp-option", "DNS", s]) dnsServers
+		redirectOpt = if redirectGateway then push ["redirect-gateway"] else []
+		dhOpt = confItem "dh" (pkiFileName inst (DHParams dhbits))
+	in
+		concat [templateConfig, serverOpt, pemOpts, dnsOpts, redirectOpt, dhOpt]
+
+templateConfig :: [String]
+templateConfig = [
+	"# Network options",
+	"",
+	"port 1194",
+	"proto udp",
+	"dev tun",
+	"",
+	"# Server options",
+	"topology subnet",
+	"ifconfig-pool-persist ipp.txt",
+	"keepalive 10 120",
+	"comp-lzo",
+	"",
+	"# Push to client",
+	"",
+	"push \"comp-lzo yes\"",
+	"# The persist options will try to avoid",
+	"# accessing certain resources on restart",
+	"# that may no longer be accessible because",
+	"# of the privilege downgrade.",
+	"persist-key",
+	"persist-tun",
+	"",
+	"# Set the appropriate level of log",
+	"# file verbosity.",
+	"#",
+	"# 0 is silent, except for fatal errors",
+	"# 4 is reasonable for general usage",
+	"# 5 and 6 can help to debug connection problems",
+	"# 9 is extremely verbose",
+	"verb 3",
+	"",
+	"## TLS Options",
+	"# remote-cert-tls client",
+	"remote-cert-ku e0 88 80 08",
+	""]

--- a/src/Propellor/Types.hs
+++ b/src/Propellor/Types.hs
@@ -34,6 +34,7 @@ module Propellor.Types
 	, module Propellor.Types.OS
 	, module Propellor.Types.Dns
 	, module Propellor.Types.Result
+	, module Propellor.Types.PKI
 	, module Propellor.Types.ZFS
 	, propertySatisfy
 	, ignoreInfo
@@ -50,6 +51,7 @@ import Propellor.Types.Info
 import Propellor.Types.OS
 import Propellor.Types.Dns
 import Propellor.Types.Result
+import Propellor.Types.PKI
 import Propellor.Types.ZFS
 
 -- | Everything Propellor knows about a system: Its hostname,

--- a/src/Propellor/Types/PKI.hs
+++ b/src/Propellor/Types/PKI.hs
@@ -1,0 +1,35 @@
+-- | Types for managing SSL certificates.
+--
+-- Maintainer: Evan Cofsky <evan@theunixman.com>
+
+module Propellor.Types.PKI (SSLType(..), DHBits, fileName) where
+
+import System.FilePath
+
+type DHBits = Int
+
+data SSLType
+	= CRL -- ^ Certificate revocation list
+	| Chain -- ^ CA Chain
+	| Certificate -- ^ Certificate
+	| RSAKey -- ^ Private key
+	| DHParams DHBits -- ^ DH Params
+
+-- | File extensions for different SSLType types.
+fileExt :: SSLType -> String
+fileExt CRL = "crl"
+fileExt Chain = "ca-chain"
+fileExt Certificate = "cert"
+fileExt RSAKey = "key"
+fileExt (DHParams s) = "dh" ++ (show s)
+
+-- | Add the .pem to the end.
+pemName :: SSLType -> FilePath
+pemName t = fileExt t <.> "pem"
+
+-- | Create the pem file name for a given base name.
+fileName :: String -> SSLType -> FilePath
+fileName name a = do
+	case a of
+          DHParams _ -> pemName a -- ^ DH Parameters don't have other names
+          _ -> name <.> pemName a -- ^ All others are {name}.{ext}.pem

--- a/src/Propellor/Types/PrivData.hs
+++ b/src/Propellor/Types/PrivData.hs
@@ -52,7 +52,7 @@ instance IsPrivDataSource PrivDataSource where
 
 -- | A context in which a PrivDataField is used.
 --
--- Often this will be a domain name. For example, 
+-- Often this will be a domain name. For example,
 -- Context "www.example.com" could be used for the SSL cert
 -- for the web server serving that domain. Multiple hosts might
 -- use that privdata.


### PR DESCRIPTION
Special things to consider:

- Needs private data for keys
- Bootstrap on Buntish needs a special ppa for ghc 7.10.3 which also
  updates other system packages
- It generates config files for each instance of OpenVPN using a janky
  "template" (a [String] that it then just mashes values around in).
- It also adds a new repository that has a newer OpenVPN than Buntish,
  and expects the key to be in the private data (of course).

So, yeah, it's definitely going to need a bit of effort to get merged,
but I think it also raises some interesting points.