### PR TITLE
apt-software-properties-common support in typed-os branch

### DIFF
--- a/propellor.cabal
+++ b/propellor.cabal
@@ -52,7 +52,7 @@ Executable propellor-config
   GHC-Options: -threaded -Wall -fno-warn-tabs -O0
   Extensions: TypeOperators
   Hs-Source-Dirs: src
-  Build-Depends: 
+  Build-Depends:
     base >= 4.5, base < 5,
     MissingH, directory, filepath, IfElse, process, bytestring, hslogger,
     unix, unix-compat, ansi-terminal, containers (>= 0.5), network, async,
@@ -63,7 +63,7 @@ Library
   GHC-Options: -Wall -fno-warn-tabs -O0
   Extensions: TypeOperators
   Hs-Source-Dirs: src
-  Build-Depends: 
+  Build-Depends:
     base >= 4.5, base < 5,
     MissingH, directory, filepath, IfElse, process, bytestring, hslogger,
     unix, unix-compat, ansi-terminal, containers (>= 0.5), network, async,
@@ -78,7 +78,7 @@ Library
     Propellor.Property.Aiccu
     Propellor.Property.Apache
     Propellor.Property.Apt
-    Propellor.Property.AptSoftwarePropertiesCommon
+    Propellor.Property.Apt.PPA
     Propellor.Property.Cmd
     Propellor.Property.Concurrent
     Propellor.Property.Conductor


### PR DESCRIPTION
This supersedes #14 with our discussion about moving it to Apt.PPA, and trying it out on the [typed-os-requirements](https://github.com/joeyh/propellor/tree/typed-os-requirements) branch.

Also that's a really great branch. I'll rebase my OpenVPN work there, too.

Thanks!