### PR TITLE
Add MonadBaseControl instance for Propellor

### DIFF
--- a/propellor.cabal
+++ b/propellor.cabal
@@ -48,7 +48,8 @@ Executable propellor
     base >= 4.5, base < 5,
     MissingH, directory, filepath, IfElse, process, bytestring, hslogger,
     unix, unix-compat, ansi-terminal, containers (>= 0.5), network, async,
-    time, mtl, transformers, exceptions (>= 0.6), stm, text
+    time, monad-control, mtl, transformers-base, transformers, exceptions (>= 0.6),
+    stm, text
   Other-Modules:
     Propellor.DotDir
 
@@ -63,7 +64,8 @@ Executable propellor-config
     base >= 4.5, base < 5,
     MissingH, directory, filepath, IfElse, process, bytestring, hslogger,
     unix, unix-compat, ansi-terminal, containers (>= 0.5), network, async,
-    time, mtl, transformers, exceptions (>= 0.6), stm, text
+    time, monad-control, mtl, transformers-base, transformers, exceptions (>= 0.6),
+    stm, text
 
 Library
   GHC-Options: -Wall -fno-warn-tabs -O0
@@ -75,7 +77,8 @@ Library
     base >= 4.5, base < 5,
     MissingH, directory, filepath, IfElse, process, bytestring, hslogger,
     unix, unix-compat, ansi-terminal, containers (>= 0.5), network, async,
-    time, mtl, transformers, exceptions (>= 0.6), stm, text
+    time, monad-control, mtl, transformers-base, transformers, exceptions (>= 0.6),
+    stm, text
 
   Exposed-Modules:
     Propellor


### PR DESCRIPTION
I had a specific use-case that ensures a property while using a Consul session via the `consul-haskell` package (https://hackage.haskell.org/package/consul-haskell-0.4/docs/Network-Consul.html#v:withSession); in order to make it type check a `MonadBaseControl IO` instance is needed, so I added one. Hopefully this is generally useful, so I don't need to maintain a forked version of propellor!